### PR TITLE
Feature: Nested filters and filters parameters

### DIFF
--- a/examples/second.temple
+++ b/examples/second.temple
@@ -1,3 +1,5 @@
 <div id="{{id}}" class="time">
+{{ prop }}
 {{datetime | long_format}}
+{{more['prop'].value | date_format('Y-m-d H:i:s') | space}}
 </div>

--- a/parsers/variable.js
+++ b/parsers/variable.js
@@ -1,0 +1,125 @@
+(function (module) {
+  var
+    T_NAME = 'T_NAME',
+    T_STRING = 'T_STRING',
+    T_BRACKET = 'T_BRACKET', // "("
+    T_SQUARE = 'T_SQUARE', // "["
+    T_CURLY = 'T_CURLY', // "{"
+    T_APPLY = 'T_APPLY', // "|"
+    T_DOT = 'T_DOT',// "."
+    T_OTHER = 'T_OTHER';
+
+  function tokenize(str) {
+    var
+      tokens = [],
+      n = 0,
+      push = function (type, ch) {
+        if (typeof tokens[n] === "undefined")
+          tokens[n] = [type, ''];
+        if (tokens[n][0] !== type)
+          tokens[++n] = [type, ''];
+        tokens[n][1] += ch;
+      },
+      push_one = function (type, ch) {
+        push(type, ch);
+        ++n;
+      };
+
+    for (var i = 0, len = str.length; i < len; ++i) {
+      var ch = str[i];
+
+      if (/\s/.test(ch))
+        continue;
+      else if (/[a-z_]/i.test(ch))
+        push(T_NAME, ch);
+      else if (/[\(\)]/.test(ch))
+        push_one(T_BRACKET, ch);
+      else if (/[\[\]]/.test(ch))
+        push_one(T_SQUARE, ch);
+      else if (/[\{\}]/.test(ch))
+        push_one(T_CURLY, ch);
+      else if (/\./.test(ch))
+        push_one(T_DOT, ch);
+      else if (/\|/.test(ch))
+        push_one(T_APPLY, ch);
+      else if (/["']/.test(ch)) {
+        push(T_STRING, ch);
+        while (++i < len) {
+          push(T_STRING, str[i]);
+          if (str[i] == ch && str[i - 1] != '\\') {
+            break;
+          }
+        }
+      } else
+        push(T_OTHER, ch);
+    }
+
+    return tokens;
+  }
+
+  function feed_until(tokens, t_until) {
+    var t, level = 0, buffer = '';
+    while (t = tokens.shift()) {
+      buffer += t[1];
+      if (t[0] == T_BRACKET) {
+        if ('(' == t[1])
+          ++level;
+        else if (')' == t[1])
+          --level;
+      }
+      if (tokens.length > 0 && level == 0 && t_until.indexOf(tokens[0][0]) != -1)
+        break;
+    }
+    return buffer;
+  }
+
+  function parse(tokens) {
+    var t, syn = {
+      name: null,
+      accessor: null,
+      filters: []
+    };
+
+    t = tokens.shift();
+    if (t[0] == T_NAME) {
+      syn.name = t[1];
+    } else {
+      throw new Error('Variable name expected first.');
+    }
+
+    if (tokens.length > 0) {
+      if (tokens[0][0] == T_DOT || tokens[0][0] == T_SQUARE) {
+        syn.accessor = (feed_until(tokens, [T_APPLY]))
+      }
+
+      while (tokens.length > 0 && tokens[0][0] == T_APPLY) {
+        tokens.shift();
+        var filter = {
+          name: feed_until(tokens, [T_APPLY, T_BRACKET]),
+          params: null
+        };
+        if (tokens.length > 0 && tokens[0][0] == T_BRACKET) {
+          filter.params = ', ' + feed_until(tokens, T_APPLY).replace(/^\(/, '').replace(/\)$/, '');
+        }
+        syn.filters.push(filter);
+      }
+    }
+
+    if (tokens.length > 0) {
+      throw new Error('Unrecognized token: "' + tokens[0][1] + '".');
+    }
+
+    return syn;
+  }
+
+  module.exports = function (input, pid) {
+    try {
+      var syn = parse(tokenize(input));
+      syn.pid = pid + '_' + syn.name;
+      return syn;
+    } catch (err) {
+      err.message = 'Syntax Error while parsing "' + input + '" variable.\n' + err.message;
+      throw err;
+    }
+  };
+})(module);


### PR DESCRIPTION
This PR implementing nested filters feature with new variables parser. 
```
{{ var | filter_one | filter_too }}
```
:heavy_plus_sign:  adds support for filters parameters:
``` coffee
filters:
  replace: (text, search, replace) ->
    text.replace(search, replace)
```
Usage:
```
{{ var | replace('foo', 'boo') }}
```
New implementation works correctly in complicated cases:
```
{{ var['property'].value | foo({key:'value'}) | bee }}
```

Also new implementation successfully compiles and renders *[jr-form](https://github.com/KosyanMedia/jr-form)* (*explosion* fork).

To test parser, create run `./test.js`:
``` js
#!/usr/bin/env node
var vparse = require('./parsers/variable');

[
  "var",
  "var.value",
  "var['value']",
  'var["value"]',
  "var.prop['value']",
  "var['prop'][0].value",
  "var | filter",
  "var | foo | boo",
  "var | date('Y-m-d H:i:s')",
  "var | base(2, 16)",
  "var.value | foo",
  "var.value | foo | boo",
  "var['value'] | add_emoji('=)', '|-|')",
  "count | pluralize({one: '${count} item', many: '${count} items'})",
  "  use_extra_space  [ 'value' ]   |  foo (  'everywhere' ) ",
  "time | locate_time(%LOCALE%)",
  "first_name | prefix(_t(mr_ms_mrs))",
  "use | this(foo || boo) | inside",
  "nested | bracket(('|')||('|'))",
  "some.think['really'].complicated | with | some('symbols =|', 1 + 2) | and_logic(foo || boo) | too",
  "passengers | pluralize(_t(search.search_form.informer.passengers)) | capitalize"
].forEach(function (v) {
    console.log("Parse: \033[92m" + v + "\033[0m");
    try {
      console.log(vparse(v, 'pid'));
    } catch (err) {
      console.log("\033[91m" + err.message + "\033[0m");
      console.log(err.stack);
    }
  });

```